### PR TITLE
Fix connection status timeout and test import

### DIFF
--- a/src/components/ui/ConnectionStatus.tsx
+++ b/src/components/ui/ConnectionStatus.tsx
@@ -9,20 +9,26 @@ const ConnectionStatus: React.FC = () => {
 
   const checkConnection = async () => {
     setStatus('checking');
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
     try {
       // Simple health check - you might want to implement a dedicated endpoint
       const response = await fetch(`${chatService.getApiUrl()}/health`, {
         method: 'GET',
-        signal: AbortSignal.timeout(5000),
+        signal: controller.signal,
       });
-      
+
+      clearTimeout(timeoutId);
+
       if (response.ok) {
-        setStatus('connected');      } else {
+        setStatus('connected');
+      } else {
         setStatus('disconnected');
       }
     } catch {
       setStatus('disconnected');
     } finally {
+      clearTimeout(timeoutId);
       setLastChecked(new Date());
     }
   };

--- a/src/tests/components/chat/Message.test.tsx
+++ b/src/tests/components/chat/Message.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '../../../test-utils/testing-library-utils'
 import MessageComponent from '../../../components/chat/Message'
-import type { Message } from '../../types/chat'
+import type { Message } from '../../../types/chat'
 
 describe('Message Component', () => {
   const mockUserMessage: Message = {


### PR DESCRIPTION
## Summary
- fix missing fetch timeout handling in `ConnectionStatus`
- fix incorrect import path in `Message.test`

## Testing
- `npm run test:run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416e526cd0832e9bea45612d1fc4ab